### PR TITLE
ci: drop support for non-LTS node versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,11 +10,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node: [8, 10, lts/*]
+        node: [lts/*]
 
     steps:
-      - uses: actions/checkout@v2.4.0
-      - uses: actions/setup-node@v2.5.0
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
       - run: npm i


### PR DESCRIPTION
- drop support for node 8 & 10 (they've been out of LTS support for a long time)
- update checkout and setup-node versions to v3