### PR TITLE
ci: target node 12, 14, 16

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,11 @@
 ---
 name: tests
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node: [lts/*]
+        node: [12, 14, 16]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Specifically targeting latest node LTS versions 12, 14, 16. The `lts/*` shorthand does not do what I hoped it did (only targets the latest single LTS version afaict, not all LTS versions as a `*` might imply).