### PR TITLE
fix: parse dates in parentheses

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const removeMarkdown = require('remove-markdown')
 
 // patterns
 const semver = /\[?v?([\w\d.-]+\.[\w\d.-]+[a-zA-Z0-9])\]?/
-const date = /.*[ ](\d\d?\d?\d?[-/.]\d\d?[-/.]\d\d?\d?\d?).*/
+const date = /.*[ ]\(?(\d\d?\d?\d?[-/.]\d\d?[-/.]\d\d?\d?\d?)\)?.*/
 const subhead = /^###/
 const listitem = /^[*-]/
 

--- a/test/fixtures/CHANGELOG.md
+++ b/test/fixtures/CHANGELOG.md
@@ -15,6 +15,12 @@ A cool description (optional).
 * Update API
 * Fix bug #1
 
+# 2.3.1 (2018-12-19)
+
+### Fixed
+
+- Support dates in parentheses.
+
 # 2.3.0 - 2018-12-18
 
 ### Added

--- a/test/fixtures/expected.js
+++ b/test/fixtures/expected.js
@@ -43,6 +43,20 @@ module.exports = {
       }
     },
     {
+      version: '2.3.1',
+      title: '2.3.1 (2018-12-19)',
+      date: '2018-12-19',
+      body: '### Fixed' + EOL + EOL + '- Support dates in parentheses.',
+      parsed: {
+        _: [
+          'Support dates in parentheses.'
+        ],
+        Fixed: [
+          'Support dates in parentheses.'
+        ]
+      }
+    },
+    {
       version: '2.3.0',
       title: '2.3.0 - 2018-12-18',
       date: '2018-12-18',

--- a/test/fixtures/remove-markdown-expected.js
+++ b/test/fixtures/remove-markdown-expected.js
@@ -43,6 +43,20 @@ module.exports = {
       }
     },
     {
+      version: '2.3.1',
+      title: '2.3.1 (2018-12-19)',
+      date: '2018-12-19',
+      body: '### Fixed' + EOL + EOL + '- Support dates in parentheses.',
+      parsed: {
+        _: [
+          '- Support dates in parentheses.'
+        ],
+        Fixed: [
+          '- Support dates in parentheses.'
+        ]
+      }
+    },
+    {
       version: '2.3.0',
       title: '2.3.0 - 2018-12-18',
       date: '2018-12-18',

--- a/test/index.js
+++ b/test/index.js
@@ -80,7 +80,7 @@ test('callback and Promise methods should yield identical values', function (t) 
 test('accepts object as first argument', function (t) {
   t.plan(1)
 
-  parseChangelog({ filePath: filePath }, function (err, result) {
+  parseChangelog({ filePath }, function (err, result) {
     if (err) throw err
 
     t.deepEqual(result, expected)
@@ -92,7 +92,7 @@ test('accepts { removeMardown: false } option', function (t) {
   t.plan(1)
 
   const options = {
-    filePath: filePath,
+    filePath,
     removeMarkdown: false
   }
 


### PR DESCRIPTION
Allows dates that are wrapped in parentheses to be correctly parsed.

Thanks @gentoo9ball 🎩 

Closes #48 